### PR TITLE
fix: import immer without top level await

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
     # Required for testing the workflow
     branches:
       - main
-      - bum-bun-down
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -101,39 +101,27 @@ state = reducer(state, actions.close({ todoIndex: 0 }));
 The API to use immer is the same as the pure functional way, but you need to import `forState` from `reducerify/immer`.
 
 ```ts
-import { forState } from "./immer";
+import { forState } from "reducerify/immer";
 
-const { reducer, actions } = forState<TodoState>().createReducer({
-  // Action with payload
-  updateName: (state, action: ActionWithPayload<{ name: string }>) => {
-    return {
-      ...state,
-      newTodo: {
-        ...state.newTodo,
-        name: action.payload.name,
-      },
-    };
-  },
-
-  // Action without payload
-  save: (state) => {
-    return {
-      todos: [...state.todos, state.newTodo],
-      newTodo: { name: '', isClosed: false },
-    };
-  },
-
-  // Another action with payload
-  close: (state, action: ActionWithPayload<{ todoIndex: number }>) => {
-    return {
-      ...state,
-      todos: state.todos.map((todo, index) =>
-        index === action.payload.todoIndex
-          ? { ...todo, isClosed: true }
-          : todo
-      ),
-    };
-  },
+const { reducer, actions } = forState<TodoState>().createImmerReducer({
+    update_name: (state, action: ActionWithPayload<{ name: string }>) => {
+        state.new_todo = {
+            ...state.new_todo,
+            name: action.payload.name,
+        };
+    },
+    save: (state) => {
+        state.todos.push(state.new_todo);
+        state.new_todo = { name: '', is_closed: false };
+    },
+    close: (state, action: ActionWithPayload<{ todo_index: number }>) => {
+        state.todos = state.todos.map((todo, index) => {
+            if (index === action.payload.todo_index) {
+                return { ...todo, is_closed: true };
+            }
+            return todo;
+        });
+    },
 });
 ```
 

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -42,11 +42,19 @@
       "enabled": false
     }
   },
-  // For some reason biome doesn't support comments in tsconfig.json
+  "overrides": [
+    {
+      "include": ["tsconfig.json"],
+      "json": {
+        "parser": {
+          "allowComments": true,
+          "allowTrailingCommas": true
+        }
+      }
+    }
+  ],
   "files": {
     "ignore": [
-      "tsconfig.*.json",
-      "tsconfig.json",
       "dist/**"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "test": "vitest",
     "clean": "rimraf dist",
-    "build": "rimraf dist && tsdown src/index.ts src/immer.ts",
+    "build": "tsdown src/index.ts src/immer.ts",
     "lint": "biome check .",
     "ci": "pnpm build && pnpm lint && pnpm test",
     "prepare": "pnpm build",

--- a/src/immer.ts
+++ b/src/immer.ts
@@ -1,18 +1,7 @@
 // utils/createReducer.ts
 
-import type { Immutable } from 'immer';
+import { type Immutable, produce } from 'immer';
 import type { ActionCreatorMap, ActionUnion, ActionWithPayload } from './types';
-
-// immer is an optional dependency, so we need to lazy-load it
-let produce: (reducer: (state: any, action: any) => any) => any;
-
-try {
-  const immer = await import(/* webpackIgnore: true */ /* @vite-ignore */ 'immer');
-  produce = immer.produce;
-} catch (e) {
-  console.error(e);
-  throw new Error('Immer is not installed. Please install immer to use createImmerReducer.');
-}
 
 type ImmerHandler<TState> = (state: TState, action: ActionWithPayload<any>) => void;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,19 +13,11 @@
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
-    /* If transpiling with TypeScript: */
-    //    "module": "NodeNext",
-    //    "outDir": "dist",
-    //    "rootDir": "src",
-    //    "sourceMap": true,
 
     /* AND if you're building for a library: */
     "declaration": true,
     "noEmit": true,
     "module": "Preserve"
-
-    /* AND if you're building for a library in a monorepo: */
-    //    "declarationMap": true
   },
   "include": [
     "src",


### PR DESCRIPTION
This can cause compatibility issues. Tree shaking should be able remove immer when it's unnecessary